### PR TITLE
create analyze function with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ function and using it when changes are required to take place.
 
 Another is that although each function provided by `BlitzMigration` is self contained with `:up` and `:down` context awareness, 
 migrations are procedural and in the case of creating a parent table and its partitions in the same migration file, the `:down` will not 
-work because of conflicts.
+work because of conflicts. <- this needs to be further explored
 
 ## Installation
 

--- a/lib/blitz_migration/analyze.ex
+++ b/lib/blitz_migration/analyze.ex
@@ -16,7 +16,7 @@ defmodule BlitzMigration.Analyze do
     ]
   ])
 
-  def execute(table_name, unchecked_opts) do
+  def execute(table_name, unchecked_opts \\ []) do
     with {:ok, opts} <- NimbleOptions.validate(unchecked_opts, @opts_definition),
          params <- sql_params(opts)
     do

--- a/lib/blitz_migration/analyze.ex
+++ b/lib/blitz_migration/analyze.ex
@@ -1,0 +1,57 @@
+defmodule BlitzMigration.Analyze do
+  @opts_definition NimbleOptions.new!([
+    verbose: [
+      type: :boolean,
+      default: false,
+      doc: "A flag to enable detailed logging during execution"
+    ],
+    skip_locked: [
+      type: :boolean,
+      default: false,
+      doc: "A flag to enable skipping over relations with conflicting locks or relations that can't immediately be locked"
+    ],
+    columns: [
+      type: {:list, :string},
+      doc: "A list of columns on the table that will be analyzed"
+    ]
+  ])
+
+  def execute(table_name, unchecked_opts) do
+    with {:ok, opts} <- NimbleOptions.validate(unchecked_opts, @opts_definition),
+         params <- sql_params(opts)
+    do
+      Ecto.Migration.execute(
+        """
+        ANALYZE #{params[:verbose]} #{params[:skip_locked]} 
+        #{table_name} #{params[:columns]}
+        """,
+        ""
+      )
+    end
+  end
+  
+  defp sql_params(opts) do
+    default = %{
+      verbose: "",
+      skip_locked: "",
+      columns: ""
+    }
+
+    opts
+    |> handle_opt_combinations()
+    |> Enum.reduce(default, fn 
+        {:verbose, true}, acc -> %{acc | verbose: "VERBOSE"}
+        {:skip_locked, true}, acc -> %{acc | skip_locked: "SKIP_LOCKED"}
+        {:both, true}, acc -> %{acc | verbose: "(VERBOSE TRUE,", skip_locked: "SKIP_LOCKED TRUE)"}
+        {:columns, columns}, acc -> %{acc | columns: "(#{Enum.join(columns, ", ")})"}
+        {_, _}, acc -> acc
+      end)
+  end
+
+  defp handle_opt_combinations(opts) do
+    case Keyword.split(opts, [:verbose, :skip_locked]) do
+      {args, opts} when length(args) === 2 -> Keyword.put(opts, :both, true)
+      _ -> opts 
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,8 @@ defmodule BlitzMigration.MixProject do
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      package: package()
     ]
   end
 
@@ -28,6 +29,15 @@ defmodule BlitzMigration.MixProject do
       {:ecto_sql, "~> 3.10"},
       {:postgrex, ">= 0.0.0"},
       {:nimble_options, "~> 1.0"}
+    ]
+  end
+
+  defp package do
+    [
+      maintainers: ["Thomas Furland", "theblitzapp"],
+      licenses: ["MIT"],
+      links: %{github: "https://github.com/theblitzapp/blitz_migration"},
+      files: ~w(mix.exs README.md CHANGELOG.md LICENSE lib)
     ]
   end
 end

--- a/priv/repo/migrations/0006_analyze_test.exs
+++ b/priv/repo/migrations/0006_analyze_test.exs
@@ -21,5 +21,7 @@ defmodule BlitzMigration.Repo.Migrations.AnalyzeTest do
       skip_locked: true,
       columns: ["number"]
     )
+    
+    Analyze.execute(:analyze_table)
   end
 end

--- a/priv/repo/migrations/0006_analyze_test.exs
+++ b/priv/repo/migrations/0006_analyze_test.exs
@@ -1,0 +1,25 @@
+defmodule BlitzMigration.Repo.Migrations.AnalyzeTest do
+  use Ecto.Migration
+
+  alias BlitzMigration.{Index, Analyze}
+
+  def change do
+    create table(:analyze_table) do
+      add :number, :int
+    end
+
+    Index.create(
+      :analyze_table, 
+      "number_partial_idx", 
+      columns: ["number"],
+      where: "number > 0",
+      tablespace: "pg_default"
+    )
+
+    Analyze.execute(:analyze_table,
+      verbose: true,
+      skip_locked: true,
+      columns: ["number"]
+    )
+  end
+end

--- a/test/blitz_migration/analyze_test.exs
+++ b/test/blitz_migration/analyze_test.exs
@@ -1,0 +1,15 @@
+defmodule BlitzMigration.AnalyzeTest do
+  alias BlitzMigration.Repo
+  alias BlitzMigration.Repo.Migrations.AnalyzeTest
+
+  use BlitzMigration.MigrationCase, 
+    repos: [Repo]
+
+  describe "execute/2" do
+    test "success: run Analyze on column successfully" do
+      with_repo(Repo, fn repo ->
+         refute [] === run_migrations(repo, [AnalyzeTest], all: true)
+      end)
+    end
+  end
+end


### PR DESCRIPTION
A feature complete Analyze function helper for Migrations.

see [BE-2307 BlitzPG Implement Analyze helper](https://linear.app/blitz/issue/BE-2307/[blitzpg]-implement-analyze-helper)

Some questions for reviewer:
- would it be a good idea to pass `:analyze?` as an opt to `create_partition_index`?
- should usage of this be mandatory and enforced when working with partitions as stated in the linear ticket above?